### PR TITLE
Tricorder scan shows the equipment the player has.

### DIFF
--- a/lua/star_trek/tricorder/sv_tricorder.lua
+++ b/lua/star_trek/tricorder/sv_tricorder.lua
@@ -61,6 +61,18 @@ function Star_Trek.Tricorder:AnalyseScanData(ent, owner, scanData)
 		Star_Trek.Logs:AddEntry(ent, owner, math.Round(scanData.Mass, 2) .. "kg", color, TEXT_ALIGN_RIGHT)
 	end
 
+	if istable(scanData.Weapons) then
+		Star_Trek.Logs:AddEntry(ent, owner, "Equipment:", nil, TEXT_ALIGN_LEFT)
+
+		for _, weapon in ipairs(scanData.Weapons) do
+			local color
+			if weapon.HoloMatter then
+				color = Star_Trek.LCARS.ColorLightBlue
+			end
+			Star_Trek.Logs:AddEntry(ent, owner, weapon.Name, color, TEXT_ALIGN_RIGHT)
+		end
+	end
+
 	if scanData.Frozen then
 		Star_Trek.Logs:AddEntry(ent, owner, "Rigidly Attached", nil, TEXT_ALIGN_LEFT)
 	end


### PR DESCRIPTION
Tricorder scan shows the equipment the player has. Including highlighting for holomatter equipment
![image](https://user-images.githubusercontent.com/99217547/190527801-9f617876-a0cb-4464-b3f7-3841ea4b0099.png)
