### PR TITLE
Add support for Non ASCII characters for caret

### DIFF
--- a/lua/star_trek/padd/windows/log_entry_editable/cl_init.lua
+++ b/lua/star_trek/padd/windows/log_entry_editable/cl_init.lua
@@ -80,7 +80,7 @@ function SELF:OnDraw(pos, animPos)
 			if caretCharPos >= 0 and caretCharPos <= #line.Text then
 				surface.SetFont(self.TextFont)
 
-				local subString = string.sub(line.Text, 1, caretCharPos)
+				local subString = string.sub(line.Text, 1, utf8.offset(line.Text, caretCharPos))
 
 				local x = surface.GetTextSize(subString)
 				local y = self.Area1Y + self.Offset + i * self.TextHeight


### PR DESCRIPTION
Fixes weird spaces after caret when you type a Non ASCII character (ßÄËéáäåéæ ect)